### PR TITLE
Added user's home/.ssh mount

### DIFF
--- a/{{cookiecutter.project_parent_dir}}/.devcontainer/devcontainer.json
+++ b/{{cookiecutter.project_parent_dir}}/.devcontainer/devcontainer.json
@@ -15,6 +15,10 @@
 		"ms-python.python",
 		"esbenp.prettier-vscode"
 	],
+    "runArgs": [
+        "-v",
+        "${localEnv:HOME}/.ssh:/home/vscode/.ssh:ro"
+    ],
     "settings": {
         "python.pythonPath": "/home/vscode/.pyenv/versions/3.9.2/bin/python",
         "terminal.integrated.shell.linux": "/bin/bash"


### PR DESCRIPTION
- This adds the user's home/.ssh directory as a volume mount in read
  only
- Because the user's .gitconfig is copied into the running dev
  container, certain configuration options for git repos can be
  impacted. This will in most cases keep the user from having to manually
  configure the .gitconfig in the container.
- Example is that if using ssh repos, the user's ssh keys may be
  required anyways